### PR TITLE
fix: use expected pach dash nodeports

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ No Modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| namespace | (Optional) The namespace to install the release into. | `string` | `"default"` | no |
+| namespace | (Optional) The namespace to install the release into. | `string` | `"pachyderm"` | no |
 | values | (Optional) List of values in raw yaml to pass to helm. See https://github.com/pachyderm/helmchart/blob/master/pachyderm/values.yaml. | `list(string)` | <pre>[<br>  "tls:\n  certName: null # Disable TLS\n  create: null # Disable TLS\npachd:\n  logLevel: debug\n  storage:\n    backend: LOCAL\n"<br>]</pre> | no |
 
 ## Outputs

--- a/examples/testfaster/.testfaster.yml
+++ b/examples/testfaster/.testfaster.yml
@@ -63,7 +63,7 @@ launch:
   title: Pachyderm
   buttons:
     - title: Pachyderm Dash
-      port: 30600
+      port: 30080
   homepage: |
     ### Pachyderm
 

--- a/examples/testfaster/main.tf
+++ b/examples/testfaster/main.tf
@@ -30,7 +30,12 @@ resource "kubernetes_service" "pachyderm-dash" {
     port {
       port        = 8080
       target_port = 8080
-      node_port   = 30600
+      node_port   = 30080
+    }
+    port {
+      port        = 8081
+      target_port = 8081
+      node_port   = 30081
     }
     type = "NodePort"
   }


### PR DESCRIPTION
We can't use custom node ports until this is fixed: https://github.com/pachyderm/helmchart/issues/65

So for now setting them to the expected ports.

But unfortunately testfaster doesn't allow us to use these yet!